### PR TITLE
event trigger throttling

### DIFF
--- a/src/lib/triggerable-multicast-delegate.ts
+++ b/src/lib/triggerable-multicast-delegate.ts
@@ -2,6 +2,10 @@ export class TriggerableMulticastDelegate<
   T extends (...args: never[]) => unknown,
 > {
   delegates = new Set<T>();
+  executionTimeMap = new WeakMap();
+  lastExecutionTime = 0;
+  THROTTLE_MS = 100;
+
   add(fn: T) {
     this.delegates.add(fn);
   }
@@ -12,6 +16,17 @@ export class TriggerableMulticastDelegate<
     this.delegates.clear();
   }
   trigger = (...args: Parameters<T>) => {
-    for (const fn of this.delegates) fn(...args);
+    const key: WeakKey = args;
+    const now = Date.now();
+
+    if (!this.executionTimeMap.has(key)) {
+      this.executionTimeMap.set(key, 0);
+    }
+
+    if (now - this.executionTimeMap.get(key) >= this.THROTTLE_MS) {
+      this.executionTimeMap.set(key, now);
+      for (const fn of this.delegates) fn(...args);
+    }
+    // If not enough time passed, ignore this event
   };
 }


### PR DESCRIPTION
Adds event throttling for repeated triggers (moving 6 ships to Trophies will only recalculate ambitions 1 time instead of 6). 

![image](https://github.com/user-attachments/assets/b988a8da-b750-414b-8eb5-47116470b0fa)

